### PR TITLE
geoip2 directive support relative path as first argument

### DIFF
--- a/ngx_http_geoip2_module.c
+++ b/ngx_http_geoip2_module.c
@@ -312,6 +312,12 @@ ngx_http_geoip2(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     value = cf->args->elts;
 
+    if (value[1].data && value[1].data[0] != '/') {
+        if (ngx_conf_full_name(cf->cycle, &value[1], 0) != NGX_OK) {
+            return NGX_CONF_ERROR;
+        }
+    }
+
     if (gcf->databases == NULL) {
         gcf->databases = ngx_array_create(cf->pool, 2,
                                         sizeof(ngx_http_geoip2_db_t));

--- a/ngx_stream_geoip2_module.c
+++ b/ngx_stream_geoip2_module.c
@@ -279,6 +279,12 @@ ngx_stream_geoip2(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     value = cf->args->elts;
 
+    if (value[1].data && value[1].data[0] != '/') {
+        if (ngx_conf_full_name(cf->cycle, &value[1], 0) != NGX_OK) {
+            return NGX_CONF_ERROR;
+        }
+    }
+
     if (gcf->databases == NULL) {
         gcf->databases = ngx_array_create(cf->pool, 2,
                                           sizeof(ngx_stream_geoip2_db_t));


### PR DESCRIPTION
Add support for relative path in geoip2 directive. If file path is /usr/local/nginx/conf/maxmind-country.mmdb, then config could be written as bellow. the prefix was define by `configure` before compile nginx( by default, it it /usr/local/nginx).

```
http {
    ...
    geoip2 conf/maxmind-country.mmdb {
        $geoip2_data_country_code default=US source=$variable_with_ip country iso_code;
        $geoip2_data_country_name country names en;
    }
    ....
}

stream {
    ...
    geoip2 conf/maxmind-country.mmdb {
        $geoip2_data_country_code default=US source=$remote_addr country iso_code;
    }
    ...
}
```