### PR TITLE
 doc: fix dynamic module compilation commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ cd nginx-VERSION
 
 ##### To build as a dynamic module (nginx 1.9.11+):
 ```
-./configure --add-dynamic-module=/path/to/ngx_http_geoip2_module
-make
-make install
+./configure --with-compat --add-dynamic-module=/path/to/ngx_http_geoip2_module
+make modules
 ```
 
 This will produce ```objs/ngx_http_geoip2_module.so```. It can be copied to your nginx module path manually if you wish.


### PR DESCRIPTION
- https://github.com/leev/ngx_http_geoip2_module/wiki/Install-Example-Debian-Bookworm
  - does show the correct commands