### PR TITLE
Stale data after auto_reload on same IP lookup

### DIFF
--- a/ngx_http_geoip2_module.c
+++ b/ngx_http_geoip2_module.c
@@ -774,6 +774,7 @@ ngx_http_geoip2_log_handler(ngx_http_request_t *r)
         database->last_change = ngx_file_mtime(&fi);
         MMDB_close(&database->mmdb);
         database->mmdb = tmpdb;
+        ngx_memzero(&database->address, sizeof(database->address));
 
         ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                       "Reload MMDB \"%s\"",


### PR DESCRIPTION
After auto-reloading the MMDB, clear the cached 'database->address'. 
If not cleared, a subsequent lookup for the same IP would reuse the stale 'database->result' (containing pointers/offsets from the *old* DB), leading to incorrect data retrieval from the *new* DB instance.

https://github.com/leev/ngx_http_geoip2_module/issues/134